### PR TITLE
Elimina redundancia en robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Allow: /
+Disallow:
 Sitemap: https://farlands-editor.susodiz.com/sitemap.xml


### PR DESCRIPTION
La opcion "Allow: /" no esta mal, pero resulta redundante ya que, por defecto, si no hay reglas "Disallow", los bots ya pueden rastrear todo. Puede ser útil si alguna regla más abajo bloqueara algo (aun no es el caso) , y quieres asegurarte de que la raíz se permita.